### PR TITLE
let a2id_free set it's argument to NULL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,15 +38,15 @@ install: liba2id.a a2idmatch
 	cp doc/man/*.1 /usr/local/share/man/man1/
 
 manhtml:
-	mandoc -T html -Ostyle=man.css doc/man/a2idmatch.1 > \
+	mandoc -T html -Ostyle=man.css man/a2idmatch.1 > \
 	build/a2idmatch.1.html
-	mandoc -T html -Ostyle=man.css doc/man/a2id_alloc.3 > \
+	mandoc -T html -Ostyle=man.css man/a2id_alloc.3 > \
 	build/a2id_alloc.3.html
-	mandoc -T html -Ostyle=man.css doc/man/a2id_fromstr.3 > \
+	mandoc -T html -Ostyle=man.css man/a2id_fromstr.3 > \
 	build/a2id_fromstr.3.html
-	mandoc -T html -Ostyle=man.css doc/man/a2id_match.3 > \
+	mandoc -T html -Ostyle=man.css man/a2id_match.3 > \
 	build/a2id_match.3.html
-	mandoc -T html -Ostyle=man.css doc/man/a2id_parsestr.3 > \
+	mandoc -T html -Ostyle=man.css man/a2id_parsestr.3 > \
 	build/a2id_parsestr.3.html
 
 fsmpngsvg:

--- a/man/a2id_alloc.3
+++ b/man/a2id_alloc.3
@@ -33,13 +33,15 @@
 allocates a new a2id structure.
 While
 .Fa localpart
-may be NULL,
+may be
+.Dv NULL ,
 .Fa domain
 is required.
 After allocating a new structure it's type is set to be one of:
 .Bl -tag -width Ds
 .It A2IDT_DOMAINONLY
-If localpart is NULL
+If localpart is
+.Dv NULL
 .It A2IDT_GENERIC
 If both
 .Fa localpart
@@ -68,12 +70,16 @@ is set to point to
 .Dv NULL .
 .Sh RETURN VALUES
 .Fn a2id_alloc
-returns a newly allocated structure on success, or NULL on error with
+returns a newly allocated structure on success, or
+.Dv NULL
+on error with
 .Va errno
 set.
 .Pp
 .Fn a2id_free
-returns nothing but may abort if NULL is passed.
+returns nothing but may abort if
+.Dv NULL
+is passed.
 .Sh ERRORS
 .Fn a2id_alloc
 may set
@@ -82,7 +88,8 @@ to any of the following values:
 .Bl -tag -width Er
 .It Bq Er EINVAL
 .Fa domain
-was NULL.
+was
+.Dv NULL .
 .El
 .Pp
 Or any of the

--- a/man/a2id_alloc.3
+++ b/man/a2id_alloc.3
@@ -27,7 +27,7 @@
 .Fa "const char *domain"
 .Fc
 .Ft void
-.Fn a2id_free "struct a2id *a2id"
+.Fn a2id_free "struct a2id **a2id"
 .Sh DESCRIPTION
 .Fn a2id_alloc
 allocates a new a2id structure.
@@ -63,11 +63,9 @@ Each allocated a2id structure should be freed by the caller with
 .Fn a2id_free
 frees an a2id structure that was allocated by
 .Fn a2id_alloc .
-If
 .Fa a2id
-is NULL
-.Xr abort 3
-is called.
+is set to point to
+.Dv NULL .
 .Sh RETURN VALUES
 .Fn a2id_alloc
 returns a newly allocated structure on success, or NULL on error with

--- a/man/a2id_fromstr.3
+++ b/man/a2id_fromstr.3
@@ -45,14 +45,17 @@ and
 return a newly allocated a2id structure on success that should be freed with
 .Xr a2id_free 3
 when done.
-On error NULL is returned with
+On error
+.Dv NULL
+is returned with
 .Dv errno
 set.
 .Sh ERRORS
 .Bl -tag -width Er
 .It Bq Er EINVAL
 .Fa a2idstrcpy
-contains an invalid string or is NULL.
+contains an invalid string or is
+.Dv NULL .
 .El
 .Sh SEE ALSO
 .Xr a2id_free 3 ,

--- a/man/a2id_parsestr.3
+++ b/man/a2id_parsestr.3
@@ -43,7 +43,9 @@ as an A2ID and updates
 .Fa localpart
 to point to the first character of
 .Fa input
-or NULL if there is no localpart.
+or
+.Dv NULL
+if there is no localpart.
 .Fa domain
 is set to point to the
 .Sq @
@@ -53,13 +55,17 @@ Note that each valid A2ID has exactly one
 character.
 If
 .Fa firstopt
-is not NULL and the localpart has one or more options then
+is not
+.Dv NULL
+and the localpart has one or more options then
 .Fa firstopt
 is set to point to the
 .Sq +
 of the first option in
 .Fa input
-or NULL if there are no options.
+or
+.Dv NULL
+if there are no options.
 If
 .Fa nropts
 is passed it is set to contain the number of options in the localpart.
@@ -71,7 +77,9 @@ as an A2ID Selector and updates
 .Fa localpart
 to point to the first character of
 .Fa input
-or NULL if there is no localpart.
+or
+.Dv NULL
+if there is no localpart.
 .Fa domain
 is set to point to the
 .Sq @
@@ -102,14 +110,16 @@ than
 .Fa localpart
 points to the first erroneous character and
 .Fa domain
-points to NULL.
+points to
+.Dv NULL .
 If the error was encountered in the domain than
 .Fa domain
 points to the first erroneous character in
 .Fa input
 and
 .Fa localpart
-points to NULL.
+points to
+.Dv NULL .
 .Sh SEE ALSO
 .Xr a2id_fromselstr 3 ,
 .Xr a2id_fromstr 3 ,

--- a/src/a2id.c
+++ b/src/a2id.c
@@ -63,7 +63,7 @@ a2id_alloc(const char *localpart, const char *domain)
 
 err:
 	if (a2id)
-		a2id_free(a2id);
+		a2id_free(&a2id);
 
 	/* assume errno is set */
 	return NULL;
@@ -73,21 +73,23 @@ err:
  * Free an a2id structure.
  */
 void
-a2id_free(struct a2id *a2id)
+a2id_free(struct a2id **a2id)
 {
-	assert(a2id != NULL);
+	if (*a2id == NULL)
+		return;
 
-	if (a2id->localpart) {
-		free(a2id->localpart);
-		a2id->localpart = NULL;
+	if ((*a2id)->localpart) {
+		free((*a2id)->localpart);
+		(*a2id)->localpart = NULL;
 	}
 
-	if (a2id->domain) {
-		free(a2id->domain);
-		a2id->domain = NULL;
+	if ((*a2id)->domain) {
+		free((*a2id)->domain);
+		(*a2id)->domain = NULL;
 	}
 
-	free(a2id);
+	free(*a2id);
+	*a2id = NULL;
 }
 
 /*

--- a/src/a2id.h
+++ b/src/a2id.h
@@ -36,7 +36,7 @@ struct a2id {
 };
 
 struct a2id *a2id_alloc(const char *, const char *);
-void a2id_free(struct a2id *);
+void a2id_free(struct a2id **);
 struct a2id *a2id_fromstr(const char *);
 struct a2id *a2id_fromselstr(const char *);
 int a2id_parsestr(const char *, const char **, const char **, const char **,

--- a/test/testa2id.c
+++ b/test/testa2id.c
@@ -158,35 +158,35 @@ test_a2id_fromstr(void)
 	assert(id->localpart == NULL);
 	assert(strcmp(id->domain, "example.com") == 0);
 	assert(id->type == A2IDT_DOMAINONLY);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("user@example.com");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "user") == 0);
 	assert(strcmp(id->domain, "example.com") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("user+subid@example.com");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "user+subid") == 0);
 	assert(strcmp(id->domain, "example.com") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("user+flags+signature@example.com");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "user+flags+signature") == 0);
 	assert(strcmp(id->domain, "example.com") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("+service+arg1+arg2@example.com");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "+service+arg1+arg2") == 0);
 	assert(strcmp(id->domain, "example.com") == 0);
 	assert(id->type == A2IDT_SERVICE);
-	a2id_free(id);
+	a2id_free(&id);
 
 	/* Adapted list from RFC 4282 */
 	id = a2id_fromstr("joe@example.com");
@@ -194,77 +194,77 @@ test_a2id_fromstr(void)
 	assert(strcmp(id->localpart, "joe") == 0);
 	assert(strcmp(id->domain, "example.com") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("fred@foo-9.example.com");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "fred") == 0);
 	assert(strcmp(id->domain, "foo-9.example.com") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("jack@3rd.depts.example.com");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "jack") == 0);
 	assert(strcmp(id->domain, "3rd.depts.example.com") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("fred.smith@example.com");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "fred.smith") == 0);
 	assert(strcmp(id->domain, "example.com") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("fred_smith@example.com");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "fred_smith") == 0);
 	assert(strcmp(id->domain, "example.com") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("fred$@example.com");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "fred$") == 0);
 	assert(strcmp(id->domain, "example.com") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("fred=?#$&*+-/^smith@example.com");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "fred=?#$&*+-/^smith") == 0);
 	assert(strcmp(id->domain, "example.com") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("nancy@eng.example.net");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "nancy") == 0);
 	assert(strcmp(id->domain, "eng.example.net") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("eng.example.net!nancy@example.net");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "eng.example.net!nancy") == 0);
 	assert(strcmp(id->domain, "example.net") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("eng%nancy@example.net");
 	assert(id != NULL);
 	assert(strcmp(id->localpart, "eng%nancy") == 0);
 	assert(strcmp(id->domain, "example.net") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("@privatecorp.example.net");
 	assert(id != NULL);
 	assert(id->localpart == NULL);
 	assert(strcmp(id->domain, "privatecorp.example.net") == 0);
 	assert(id->type == A2IDT_DOMAINONLY);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("\\(user\\)@example.net");
 	assert(id != NULL);
@@ -272,7 +272,7 @@ test_a2id_fromstr(void)
 	assert(strcmp(id->localpart, "\\(user\\)") == 0);
 	assert(strcmp(id->domain, "example.net") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("<user>@example.net");
 	assert(id != NULL);
@@ -280,7 +280,7 @@ test_a2id_fromstr(void)
 	assert(strcmp(id->localpart, "<user>") == 0);
 	assert(strcmp(id->domain, "example.net") == 0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	id = a2id_fromstr("alice@xn--tmonesimerkki-bfbb.example.net");
 	assert(id != NULL);
@@ -288,7 +288,7 @@ test_a2id_fromstr(void)
 	assert(strcmp(id->domain, "xn--tmonesimerkki-bfbb.example.net") ==
 	    0);
 	assert(id->type == A2IDT_GENERIC);
-	a2id_free(id);
+	a2id_free(&id);
 
 	/* test invalid ids */
 	assert(a2id_fromstr("") == NULL);


### PR DESCRIPTION
Using assert(3) to catch cases where freed objects are inadvertently used should
be done in all but the a2id_free function itself. This way errors can be caught
in a secure way in all the other functions, instead of only in the a2id_free
function. Although no longer detectable in a2id_free, accepting and returning
NULL is idiomatic with free(3) and not a security issue because the behaviour
avoids a double free.

Triggered by reading the changelog of Tor 0.3.3.9.